### PR TITLE
fix(resolveEndpoints): add deno-lint-ignore directive and type

### DIFF
--- a/static/resolveEndpoints.ts
+++ b/static/resolveEndpoints.ts
@@ -47,7 +47,7 @@ async function generateEndpointsFile() {
   const targetFolder = getFolderFromArgs();
   const rootPath = path.join(currentDir, targetFolder);
 
-  let endpointsContent = 'const endpoints = [\n';
+  let endpointsContent = '// deno-lint-ignore no-explicit-any\n' + 'const endpoints: any[] = [\n';
 
   await walkDirectory(rootPath, (file) => {
     const extension = path.extname(file.path);


### PR DESCRIPTION
Updated the endpoint file content to have deno lint ignore directive and type annotation

Related: https://github.com/yelixjs/yelix/pull/42